### PR TITLE
Rotation and H2O fix, Psi4 replaced by QCElemental

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: CodeCov
+name: CI
 on: [push, pull_request]
 jobs:
   run:

--- a/base.yaml
+++ b/base.yaml
@@ -1,13 +1,13 @@
 name: test
 channels:
   - defaults
-  - psi4
+  #- psi4
 dependencies:
     # Base
   - numpy
   - python
   - qcelemental
-  - psi4
+  #- psi4
   - pytest
   - pytest-cov
   - coverage

--- a/base.yaml
+++ b/base.yaml
@@ -1,7 +1,7 @@
 name: test
 channels:
   - defaults
-  #- psi4
+  - psi4
 dependencies:
     # Base
   - numpy

--- a/molsym/flowchart.py
+++ b/molsym/flowchart.py
@@ -1,5 +1,5 @@
 import numpy as np
-import psi4
+#import psi4
 from math import isclose
 from molsym.molecule import *
 from molsym.symtools import *

--- a/molsym/flowchart.py
+++ b/molsym/flowchart.py
@@ -57,7 +57,7 @@ def find_point_group(mol):
                     else:
                         if sigmav_chk:
                             if sigmav.any():
-                                saxis = sigmav
+                                saxis = np.cross(paxis,sigmav)
                             pg = "C2v"
                         else:
                             S4 = Sn(c2, 4)

--- a/molsym/molecule.py
+++ b/molsym/molecule.py
@@ -1,5 +1,6 @@
 import numpy as np
-import psi4
+#import psi4
+import qcelemental as qcel
 import json
 from dataclasses import dataclass
 from copy import deepcopy
@@ -28,10 +29,14 @@ class Molecule():
 
     @classmethod
     def from_schema(cls, schema):
-        atoms = schema["elem"]
+        atoms = schema["symbols"]
         natoms = len(atoms)
-        coords = np.reshape(schema["geom"], (natoms,3))
-        masses = schema["mass"]
+        coords = np.reshape(schema["geometry"], (natoms,3))
+        # As of now, QCElemental seems to have issues assigning masses, so I do it
+        masses = np.zeros(natoms)
+        for (idx, symb) in enumerate(atoms):
+            masses[idx] = qcel.periodictable.to_mass(symb)
+        #masses = schema["masses"]
         return cls(atoms, coords, masses)
 
     def __getitem__(self, i):

--- a/molsym/molecule.py
+++ b/molsym/molecule.py
@@ -27,11 +27,11 @@ class Molecule():
         self.masses = np.asarray(masses)
 
     @classmethod
-    def from_schema(cls, squeema):
-        atoms = squeema["elem"]
+    def from_schema(cls, schema):
+        atoms = schema["elem"]
         natoms = len(atoms)
-        coords = np.reshape(squeema["geom"], (natoms,3))
-        masses = squeema["mass"]
+        coords = np.reshape(schema["geom"], (natoms,3))
+        masses = schema["mass"]
         return cls(atoms, coords, masses)
 
     def __getitem__(self, i):
@@ -79,7 +79,6 @@ class Molecule():
     def find_SEAs(self):
         dm = self.distance_matrix()
         out = []
-        nate_thang = []
         for i in range(self.natoms):
             for j in range(i+1,self.natoms):
                 a_idx = np.argsort(dm[i,:])
@@ -93,10 +92,10 @@ class Molecule():
                         chk = False
                 if chk:
                     out.append((i,j))
-        nonos = []
+        skip = []
         SEAs = []
         for i in range(self.natoms):
-            if i in nonos:
+            if i in skip:
                 continue
             else:
                 biggun = [i]
@@ -105,10 +104,10 @@ class Molecule():
                 if i in k:
                     if i == k[0]:
                         biggun.append(k[1])
-                        nonos.append(k[1])
+                        skip.append(k[1])
                     else:
                         biggun.append(k[0])
-                        nonos.append(k[0])
+                        skip.append(k[0])
             SEAs.append(SEA("", biggun, np.zeros(3)))
         return SEAs
 
@@ -170,12 +169,3 @@ def calcmoit(atoms):
                 for k in range(atoms.natoms):
                     I[i,j] -= atoms.masses[k]*atoms.coords[k,i]*atoms.coords[k,j]
     return I
-
-#if __name__ == "__main__":
-#    with open("xyz/water.xyz", "r") as fn:
-#        strang = fn.read()
-#    psimol = psi4.core.Molecule.from_string(strang)
-#    schema = psimol.to_schema("psi4")
-#    mol = Molecule.from_schema(schema)
-#    seas = mol.find_SEAs()
-#    print(seas)

--- a/molsym/symtext/main.py
+++ b/molsym/symtext/main.py
@@ -375,9 +375,12 @@ def cn_class_map(class_map, n, idx_offset, cls_offset):
     return class_map
 
 def rotate_mol_to_symels(mol, paxis, saxis):
-    phi, theta, chi = get_euler_angles(paxis, saxis)
-    dc = dc_mat(phi, theta, chi)
-    new_mol = mol.transform(dc)
+    z = paxis
+    x = saxis
+    y = np.cross(z,x)
+    rmat = np.column_stack((x,y,z)) # This matrix rotates z to paxis, etc., ...
+    rmat_inv = rmat.T # ... so invert it so it takes paxis to z, etc.
+    new_mol = mol.transform(rmat_inv)
     return new_mol
 
 def rotate_symels_to_mol(symels, paxis, saxis):
@@ -433,7 +436,6 @@ def get_atom_mapping(mol, symels):
     for (a, atom) in enumerate(mol):
         for (s, symel) in enumerate(symels):
             w = where_you_go(mol, a, symel)
-            print(w)
             if w is not None:
                 amap[a,s] = w
             else:
@@ -451,10 +453,10 @@ def where_you_go(mol, atom, symel):
 def symtext_from_file(fn):
     with open(fn, "r") as lfn:
         strang = lfn.read()
-    mool = psi4.core.Molecule.from_string(strang)
-    beebus = mool.to_schema("psi4")
-    mol = Molecule.from_schema(beebus)
-    return symtext_from_mol(mol)
+    mol = psi4.core.Molecule.from_string(strang)
+    schema = mol.to_schema("psi4")
+    mol2 = Molecule.from_schema(schema)
+    return symtext_from_mol(mol2)
 
 def symtext_from_mol(mol):
     mol.translate(mol.find_com())

--- a/molsym/symtext/main.py
+++ b/molsym/symtext/main.py
@@ -2,7 +2,7 @@ from .symtext import *
 from .symel_generators import *
 from .character_table_generators import *
 from molsym.symtools import normalize
-import psi4
+#import psi4
 from molsym.flowchart import find_point_group
 from .multiplication_table import *
 
@@ -453,8 +453,10 @@ def where_you_go(mol, atom, symel):
 def symtext_from_file(fn):
     with open(fn, "r") as lfn:
         strang = lfn.read()
-    mol = psi4.core.Molecule.from_string(strang)
-    schema = mol.to_schema("psi4")
+    #mol = psi4.core.Molecule.from_string(strang)
+    schema = qcel.models.Molecule.from_data(strang).dict()
+    print(schema)
+    #schema = mol.to_schema("psi4")
     mol2 = Molecule.from_schema(schema)
     return symtext_from_mol(mol2)
 

--- a/molsym/symtext/symtext.py
+++ b/molsym/symtext/symtext.py
@@ -64,7 +64,7 @@ class Symtext():
         self.mult_table = mult_table
         self.order = len(symels)
     def __repr__(self):
-        return f"\n{self.chartable}\n{self.symels}\n{self.class_map}\n{self.atom_map}\n{self.mult_table}"
+        return f"\n{self.chartable}\n{self.symels}\nClass map:\n{self.class_map}\nAtom map:\n{self.atom_map}\nMultiplication Table\n{self.mult_table}"
 def reduce(n, i):
     g = gcd(n, i)
     return n//g, i//g # floor divide to get an int, there should never be a remainder since we are dividing by the gcd

--- a/molsym/symtools.py
+++ b/molsym/symtools.py
@@ -216,12 +216,10 @@ def c2b(mol, sea, axis=None, all=False):
     out = []
     for i in range(length):
         c2_axis = normalize(mol.coords[sea.subset[i],:])
-        print("Jimbo")
         if c2_axis is None:
             continue
         if axis is not None and issame_axis(c2_axis, axis):
             continue
-        print("Bimbo")
         c2 = Cn(c2_axis, 2)
         molB = mol.transform(c2)
         if isequivalent(mol, molB):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,6 @@ requires-python = ">=3.9"
 [options]
 install_requires = [
     "numpy >= 1.23.4",
-    "psi4 >= 1.6.1"
+    "qcelemental >= 0.25.1"
     ]
 

--- a/test/test_character_tables.py
+++ b/test/test_character_tables.py
@@ -13,22 +13,22 @@ from test_symels import pgs
 
 def test_CharTable():
     for pg in pgs:
-        ctab_a = pg_to_chartab(pg)
-        ctab_b = CharTable(pg,np.array(eval(pg+"irr")),np.array(eval(pg+"cn")),None,eval(pg+"ct"),None)
-        beans = ctab_a == ctab_b
+        ctab = pg_to_chartab(pg)
+        ctab_ans = CharTable(pg,np.array(eval(pg+"irr")),np.array(eval(pg+"cn")),None,eval(pg+"ct"),None)
+        beans = ctab == ctab_ans
         if not beans:
-            print(ctab_a)
+            print(ctab)
             print("Ref.")
-            print(ctab_b)
-            tab_chk = ctab_a.characters == ctab_b.characters
-            irr_chk = ctab_a.irreps == ctab_b.irreps
-            name_chk = ctab_a.classes == ctab_b.classes
+            print(ctab_ans)
+            tab_chk = ctab.characters == ctab_ans.characters
+            irr_chk = ctab.irreps == ctab_ans.irreps
+            name_chk = ctab.classes == ctab_ans.classes
             print(f"Table Check: {tab_chk.all()}")
             print(f"Irrep. Check: {irr_chk.all()}")
             print(f"Name Check: {name_chk.all()}")
             if not tab_chk.all():
                 print(tab_chk)
-                print(ctab_a.characters-ctab_b.characters)
+                print(ctab.characters-ctab_ans.characters)
             elif not name_chk.all():
                 print(name_chk)
         assert beans

--- a/test/test_find_pg.py
+++ b/test/test_find_pg.py
@@ -1,5 +1,6 @@
 from molsym.flowchart import find_point_group
-import psi4
+#import psi4
+import qcelemental as qcel
 from molsym.molecule import Molecule
 
 names = ["C1", "Ci", "Cs", "Cs_nonplanar", "C2", "C3", "S4", "C2v", "C3v", "C2h", "C3h", "D2", "D3", "D2d", "D4d", "D3h", "D4h", "D5h", "D6h", "D12h", "D100h", 
@@ -16,9 +17,10 @@ def test_find_point_group():
         pg_ans = pgs[i]
         with open("test/sxyz/"+fn+".xyz", "r") as fn:
             strang = fn.read()
-        mool = psi4.core.Molecule.from_string(strang)
-        beebus = mool.to_schema("psi4")
-        mol = Molecule.from_schema(beebus)
+        #mool = psi4.core.Molecule.from_string(strang)
+        schema = qcel.models.Molecule.from_data(strang).dict()
+        #beebus = mool.to_schema("psi4")
+        mol = Molecule.from_schema(schema)
         pg, (paxis, saxis) = find_point_group(mol)
         print("Ans: ", pg)
         assert pg_ans == pg

--- a/test/test_symels.py
+++ b/test/test_symels.py
@@ -20,22 +20,22 @@ pgs = [
 
 def test_Symel():
     for pg in pgs:
-        symels_a = pg_to_symels(pg)
-        symels_b = eval(pg+"s")
+        symels = pg_to_symels(pg)
+        symels_ans = eval(pg+"s")
         beans = True
-        a_len = len(symels_a)
-        b_len = len(symels_b)
-        if a_len != b_len:
+        slen = len(symels)
+        slen_ans = len(symels_ans)
+        if slen != slen_ans:
             beans = False
-        for i in range(a_len):
-            if symels_a[i] == symels_b[i]:
+        for i in range(slen):
+            if symels[i] == symels_ans[i]:
                 continue
             else:
-                print(f"{pg} Symels {symels_a[i]} and {symels_b[i]} do not match!")
+                print(f"{pg} Symels {symels[i]} and {symels_ans[i]} do not match!")
                 print("Calculated:")
-                print(symels_a)
+                print(symels)
                 print("Ref:")
-                print(symels_b)
+                print(symels_ans)
                 beans = False
         assert beans
 

--- a/test/test_symels.py
+++ b/test/test_symels.py
@@ -39,28 +39,6 @@ def test_Symel():
                 beans = False
         assert beans
 
-#def test_CharTable():
-#    for pg in pgs:
-#        ctab_a = pg_to_chartab(pg)
-#        ctab_b = CharTable(pg,np.array(eval(pg+"irr")),np.array(eval(pg+"cn")),None,eval(pg+"ct"),None)
-#        beans = ctab_a == ctab_b
-#        if not beans:
-#            print(ctab_a)
-#            print("Ref.")
-#            print(ctab_b)
-#            tab_chk = ctab_a.characters == ctab_b.characters
-#            irr_chk = ctab_a.irreps == ctab_b.irreps
-#            name_chk = ctab_a.classes == ctab_b.classes
-#            print(f"Table Check: {tab_chk.all()}")
-#            print(f"Irrep. Check: {irr_chk.all()}")
-#            print(f"Name Check: {name_chk.all()}")
-#            if not tab_chk.all():
-#                print(tab_chk)
-#                print(ctab_a.characters-ctab_b.characters)
-#            elif not name_chk.all():
-#                print(name_chk)
-#        assert beans
-
 def test_symtext():
     #for i in range(2,7):
     #    pg = f"D{i}h"


### PR DESCRIPTION
- Rotations of the molecule to the Symel frame are now done by a simple matrix inversion
- Water is now oriented such that for STO-3G, there is a single B1 SALC and two B2 SALCs
- Psi4 replaced by QCElemental for file parsing