### PR TITLE
Bug fix: Inconsistent early return

### DIFF
--- a/molsym/symtext/main.py
+++ b/molsym/symtext/main.py
@@ -388,7 +388,8 @@ def cn_class_map(class_map, n, idx_offset, cls_offset):
 def rotate_mol_to_symels(mol, paxis, saxis):
     if np.isclose(np.linalg.norm(paxis), 0.0, atol=global_tol): 
         # Symmetry is C1 and paxis not defined, just return mol
-        return mol
+        rmat = rmat_inv = np.eye(3)
+        return mol, rmat, rmat_inv
     z = paxis
     if np.isclose(np.linalg.norm(saxis), 0.0, atol=global_tol): 
         trial_vec = np.array([1.0,0.0,0.0])


### PR DESCRIPTION
I ran into this bug in the early return statement that seemed simple enough for me to fix, so I thought I would submit a PR.

Note: I had the function just return an identity matrix for rmat and rmat_inv. Not sure if that matters.