### PR TITLE
Bug fix: Build coordinate system w/o s-axis

### DIFF
--- a/molsym/symtext/main.py
+++ b/molsym/symtext/main.py
@@ -392,10 +392,13 @@ def rotate_mol_to_symels(mol, paxis, saxis):
         return mol, rmat, rmat_inv
     z = paxis
     if np.isclose(np.linalg.norm(saxis), 0.0, atol=global_tol): 
-        trial_vec = np.array([1.0,0.0,0.0])
-        if np.isclose(np.dot(trial_vec, z), 1.0, atol=global_tol):
-            trial_vec = np.array([0.0,1.0,0.0])
-        x = normalize(np.cross(trial_vec, z))
+        # Find a trial vector that works
+        x = None
+        for trial_vec in np.eye(3):
+            x = np.cross(trial_vec, z)
+            if not np.isclose(np.linalg.norm(x), 0, atol=global_tol):
+                x = normalize(x)
+                break
         y = normalize(np.cross(z, x))
     else:
         x = saxis


### PR DESCRIPTION
Here's another one. I had to do this to get your C3 molecule example to work for me:

```
H    1.000    1.000000    0.000000
H    1.000   -0.500000    0.866025
H    1.000   -0.500000   -0.866025
C   -1.000    0.984808    0.173648
C   -1.000   -0.642788    0.766044
C   -1.000   -0.342020   -0.939693
```