### PR TITLE
Bug fix: Allow tolerance in planarity check

### DIFF
--- a/molsym/symtools.py
+++ b/molsym/symtools.py
@@ -294,7 +294,7 @@ def is_there_sigmav(mol, SEAs, paxis):
     return False, None
 
 def mol_is_planar(mol):
-    rank = np.linalg.matrix_rank(mol.coords)
+    rank = np.linalg.matrix_rank(mol.coords, tol=mol.tol)
     if rank < 3:
         return True
     return False

--- a/test/test_find_pg.py
+++ b/test/test_find_pg.py
@@ -1,8 +1,11 @@
+import os
 from molsym.flowchart import find_point_group
 #import psi4
 import qcelemental as qcel
 from molsym.molecule import Molecule
 import pytest
+
+PATH = os.path.dirname(os.path.realpath(__file__))
 
 names = ["C1", "Ci", "Cs", "Cs_nonplanar", "C2", "C3", "S4", "C2v", "C3v", "C2h", "C3h", "D2", "D3", "D2d", "D4d", "D3h", "D4h", "D5h", "D6h", "D12h", "D100h", 
          "Cinfv", "Dinfh", "Th", "Td", "cube", "octahedron", "dodecahedron", "icosahedron"]
@@ -14,7 +17,8 @@ pgs = ["C1", "Ci", "Cs", "Cs", "C2", "C3", "S4", "C2v", "C3v", "C2h", "C3h", "D2
 
 @pytest.mark.parametrize("name, pg_ans", [(names[i], pgs[i]) for i in range(len(names))])
 def test_find_point_group(name, pg_ans):
-    with open("test/sxyz/"+name+".xyz", "r") as fn:
+    file_path = os.path.join(PATH, "sxyz", f"{name}.xyz")
+    with open(file_path, "r") as fn:
         strang = fn.read()
     schema = qcel.models.Molecule.from_data(strang).dict()
     mol = Molecule.from_schema(schema)

--- a/test/test_symels.py
+++ b/test/test_symels.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import numpy as np
 from pgs.Cn import *
@@ -9,6 +10,8 @@ from pgs.Dnd import *
 from pgs.Sn import *
 from molsym.symtext.main import pg_to_symels, pg_to_chartab, cn_class_map, generate_symel_to_class_map
 from molsym import Symtext
+
+PATH = os.path.dirname(os.path.realpath(__file__))
 
 pgs = [
     "C2","C3","C4","C5","C6",
@@ -45,4 +48,5 @@ def test_symtext():
     #    pg = f"D{i}h"
     #    beans = generate_symel_to_class_map(pg_to_symels(pg),pg_to_chartab(pg))
     #    print(f"pg: {pg}, {beans}")
-    print(Symtext.from_file("test/sxyz/D6h.xyz"))
+    file_path = os.path.join(PATH, "sxyz", "D6h.xyz")
+    print(Symtext.from_file(file_path))


### PR DESCRIPTION
This was preventing near-Cs molecules from being correctly symmetrized.